### PR TITLE
- Change Ok to OK

### DIFF
--- a/src/www/views/mechanicsEngine.html
+++ b/src/www/views/mechanicsEngine.html
@@ -171,7 +171,7 @@
             </label>
         </div>
         <div class="mechanics-mealButtonDiv">
-            <button class="btn btn-primary btn-block" type="button">Ok</button>
+            <button class="btn btn-primary btn-block" type="button">OK</button>
         </div>
     </div>
 


### PR DESCRIPTION
This is a very minor edit, but here ya go.  I'd argue that it's more correct to use "OK" rather than "Ok."  If you are spelling it out as a word with normal sentence capitalization, you'd use "Okay."  But "Ok" to my eyes reads like a sound you might utter when you stub your toe.

https://en.wiktionary.org/wiki/OK