### PR TITLE
Rework how quivers work

### DIFF
--- a/src/ts/controller/actionChartController.ts
+++ b/src/ts/controller/actionChartController.ts
@@ -123,8 +123,13 @@ const actionChartController = {
         if( !o )
             return;
         
-        // Number of arrows on the quiver (to keep it on the dropped object)
-        const arrows = ( objectId == 'quiver' ? state.actionChart.arrows : 0 );
+        var count = 0;
+        if( objectId == 'quiver' ) {
+            // Number of arrows on the quiver (to keep it on the dropped object)
+            count = state.actionChart.arrows % 6;
+            if( count == 0 && state.actionChart.arrows > 0 )
+                count = 6;
+        }
 
         if( state.actionChart.drop(objectId) ) {
             actionChartView.showInventoryMsg('drop', o , 
@@ -140,7 +145,7 @@ const actionChartController = {
             if( availableOnSection ) {
                 // Add the droped object as available on the current section
                 var sectionState = state.sectionStates.getSectionState();
-                sectionState.addObjectToSection( objectId , 0 , false , arrows );
+                sectionState.addObjectToSection( objectId , 0 , false , count );
 
                 // Render available objects on this section (game view)
                 mechanicsEngine.fireInventoryEvents( fromUI , o );
@@ -355,6 +360,7 @@ const actionChartController = {
         actionChartController.pickItemsList( inventoryState.backpackItems );
         actionChartController.pickItemsList( inventoryState.specialItems );
         actionChartController.increaseMoney( inventoryState.beltPouch );
+        actionChartController.increaseArrows( inventoryState.arrows );
         actionChartController.increaseMeals( inventoryState.meals );
     },
 

--- a/src/ts/model/actionChart.ts
+++ b/src/ts/model/actionChart.ts
@@ -20,6 +20,7 @@ interface InventoryState {
     backpackItems: Array<string>;
     specialItems: Array<string>;
     beltPouch: number;
+    arrows: number;
     meals: number;
 }
 
@@ -79,7 +80,7 @@ class ActionChart {
     /** The latests scroll position on the game section */
     public yScrollPosition = 0;
 
-    /** Number of arrows on the quiver. This MUST to be zero if the player has no quiver. */
+    /** Number of arrows on the quiver. This MUST be zero if the player has no quiver. */
     public arrows = 0;
 
     /** The player has used adgana previously? (see "pouchadgana" object) */
@@ -267,8 +268,8 @@ class ActionChart {
         if( this.backpackItems.removeValue(objectId) || this.specialItems.removeValue(objectId)) {
             this.checkMaxEndurance();
             this.checkCurrentWeapon();
-            if( objectId == 'quiver' )
-                this.arrows = 0;
+            if( objectId == Item.QUIVER )
+                this.sanitizeArrowCount();
             return true;
         }
         
@@ -614,6 +615,7 @@ class ActionChart {
                 backpackItems: this.backpackItems.clone(),
                 specialItems: this.specialItems.clone(),
                 beltPouch: this.beltPouch,
+                arrows: this.arrows,
                 meals: this.meals
             };
         else if( objectTypes == 'weaponlike' ) {
@@ -623,6 +625,7 @@ class ActionChart {
                 backpackItems: [],
                 specialItems: [],
                 beltPouch: 0,
+                arrows: 0,
                 meals: 0
             };
 
@@ -650,8 +653,21 @@ class ActionChart {
             backpackItems: s1.backpackItems.concat( s2.backpackItems ),
             specialItems: s1.specialItems.concat ( s2.specialItems ),
             beltPouch: s1.beltPouch + s2.beltPouch,
+            arrows: s1.arrows + s2.arrows,
             meals: s1.meals + s2.meals
         };
+    }
+
+    /**
+     * Makes sure the arrow count fits our current quiver count
+     */
+    private sanitizeArrowCount() {
+        var max = 0;
+        for( var i=0; i<this.specialItems.length; i++ ) {
+            if( this.specialItems[i] == Item.QUIVER )
+                max += 6;
+        }
+        this.arrows = Math.max( 0, Math.min( this.arrows, max ) );
     }
 
     /**
@@ -659,11 +675,8 @@ class ActionChart {
      * @param increment N. of arrows to increment. Negative to decrement
      */
     public increaseArrows(increment : number) {
-        if( !this.hasObject( Item.QUIVER ) )
-            return;
         this.arrows += increment;
-        if( this.arrows < 0 )
-            this.arrows = 0;
+        this.sanitizeArrowCount();
     }
 
     /**

--- a/src/ts/model/sectionState.ts
+++ b/src/ts/model/sectionState.ts
@@ -233,14 +233,14 @@ class SectionState {
      * @param objectId Object id to add
      * @param price The object price
      * @param unlimited True if there are an infinite number of this kind of object on the section
-     * @param count Only applies if id = 'quiver' (number of arrows on the quiver) or 'money' (number of Gold Crowns)
+     * @param count Only applies if id = 'quiver' (number of arrows on the quiver), 'arrow', or 'money' (number of Gold Crowns)
      * @param useOnSection The object is allowed to be used on the section (not picked object)?
      */
     public addObjectToSection(objectId : string , price : number = 0, unlimited : boolean = false, count : number = 0 ,
         useOnSection : boolean = false ) {
 
         // Special cases:
-        if( objectId == 'money' || objectId == 'quiver' ) {
+        if( objectId == 'money' ) {
             // Try to increase the current money amount / arrows on the section:
             for( let o of this.objects ) {
                 if( o.id == objectId ) {
@@ -254,7 +254,7 @@ class SectionState {
             id: objectId,
             price: price,
             unlimited: unlimited,
-            count: (objectId == 'quiver' || objectId == 'money' ? count : 0 ),
+            count: (objectId == 'quiver' || objectId == 'arrow' || objectId == 'money' ? count : 0 ),
             useOnSection: useOnSection
         });
     }

--- a/src/ts/views/viewsUtils/objectsTable.ts
+++ b/src/ts/views/viewsUtils/objectsTable.ts
@@ -28,13 +28,13 @@ class ObjectsTableItem {
 
     /**
      * Constructor
-     * @param itemInfo Object info. It can be a string with the object id, or a SectionItem with the object info
+     * @param itemInfo Object info as a SectionItem
      * on the section
      * @param type Table type
      */
-    constructor( itemInfo : any , type : ObjectsTableType ) {
+    constructor( itemInfo : SectionItem , type : ObjectsTableType ) {
         this.type = type;
-        this.objectInfo = this.toSectionItem( itemInfo );
+        this.objectInfo = itemInfo;
 
         // Get the object info
         if( this.objectInfo )
@@ -61,10 +61,10 @@ class ObjectsTableItem {
 
         // If it's a sell table, and we don't have the object, do not show it
         if( this.type == ObjectsTableType.SELL  ) {
-            if( !state.actionChart.hasObject( this.objectInfo.id ) )
+            if( this.objectInfo.id != 'arrow' && !state.actionChart.hasObject( this.objectInfo.id ) )
                 return '';
             // We don't have enougth arrows to sell, do not show
-            if( this.objectInfo.id == 'quiver' && state.actionChart.arrows < this.objectInfo.count )
+            if( this.objectInfo.id == 'arrow' && state.actionChart.arrows < this.objectInfo.count )
                 return '';
         }
 
@@ -78,6 +78,11 @@ class ObjectsTableItem {
             // Be sure count is not null
             const count = ( this.objectInfo.count ? this.objectInfo.count : 0 );
             name += ' (' + count + ' ' + translations.text('arrows') + ')';
+        }
+
+        // Arrow amount
+        if( this.objectInfo.id == 'arrow' && this.objectInfo.count ) {
+            name = this.objectInfo.count + ' ' + name;
         }
 
         // Money amount
@@ -124,7 +129,7 @@ class ObjectsTableItem {
     private getOperationTag(operation : string, title : string = null , opDescription : string ) {
         let link = '<a href="#" data-objectId="' + this.item.id + '" class="equipment-op btn btn-default" ';
 
-        if( this.item.id == 'quiver' || this.item.id == 'money' )
+        if( this.item.id == 'quiver' || this.item.id == 'arrow' || this.item.id == 'money' )
             // Store the number of arrows on the quiver / gold crowns
             link += 'data-count="' + this.objectInfo.count + '" ';
 
@@ -247,42 +252,6 @@ class ObjectsTableItem {
         return new ObjectsTableItem( objectInfo , tableType );
     }
 
-    /**
-     * Convert, if needed, the string object id to a SectionItem
-     * @param objectInfo A string with the object id, or a SectionItem with the object info
-     * @return A SectionItem with the object info
-     */
-    private toSectionItem( info : any ) : SectionItem {
-
-        if( !info )
-            return null;
-        
-        if( typeof(info) === 'string' ) {
-
-            let count = 0;
-            if( this.type == ObjectsTableType.INVENTORY && info == 'quiver' )
-                // The current number of arrows on the quiver:
-                count = state.actionChart.arrows;
-
-            return { 
-                // The object info is directly the object id
-                id : info,
-                price : 0,
-                unlimited : false,
-                count : count,
-                useOnSection : false
-            }
-        }
-        else if( info.id ) {
-            // The object info is the info about objects available on the section
-            // See SectionState.objects documentation
-            return info as SectionItem;
-        }
-        else 
-            return null;
-        
-    }
-
     ///////////////////////////////////////////////////////////////////////
     // OPERATIONS
     ///////////////////////////////////////////////////////////////////////
@@ -314,10 +283,7 @@ class ObjectsTableItem {
         }
 
         let objectPicked : boolean;
-        if( this.item.id == 'quiver' && state.actionChart.hasObject(this.item.id) )
-            // Do not pick two quivers
-            objectPicked = true;
-        else if( this.item.id == 'money' )
+        if( this.item.id == 'money' || this.item.id == 'arrow' )
             // Not really an object
             objectPicked = true;
         else
@@ -327,7 +293,7 @@ class ObjectsTableItem {
 
             let countPicked = this.objectInfo.count;
 
-            if( this.item.id == 'quiver' )
+            if( this.item.id == 'quiver' || this.item.id == 'arrow' )
                 // Increase the number of arrows on the quiver
                 actionChartController.increaseArrows( this.objectInfo.count );
 
@@ -355,7 +321,7 @@ class ObjectsTableItem {
         if( !confirm( translations.text( 'confirmSell' , [ this.objectInfo.price ] ) ) )
             return;
 
-        if( this.item.id == 'quiver' && this.objectInfo.count > 0 )
+        if( this.item.id == 'arrow' && this.objectInfo.count > 0 )
             // Drop arrows
             actionChartController.increaseArrows( -this.objectInfo.count );
         else
@@ -425,8 +391,39 @@ class ObjectsTable {
 
         this.type = type;
         this.$tableBody = $tableBody;
-        for( let o of objects )
-            this.objects.push( new ObjectsTableItem(o, type) );
+
+        this.fillObjectsList( objects );
+    }
+
+    /**
+     * Converts the provided array of either strings or SectionItems to
+     * a proper array of ObjectsTableItems.
+     */
+    public fillObjectsList( objects : Array<any> ) {
+        let arrows = ( this.type == ObjectsTableType.INVENTORY ) ? state.actionChart.arrows : 0;
+
+        for( let obj of objects ) {
+            let info = obj;
+
+            if( typeof(obj) === 'string' ) {
+                let count = 0;
+
+                if( obj == Item.QUIVER ) {
+                    count = Math.min( 6, arrows );
+                    arrows -= count;
+                }
+
+                info = {
+                    id : obj,
+                    price : 0,
+                    unlimited : false,
+                    count : count,
+                    useOnSection : false
+                }
+            }
+
+            this.objects.push( new ObjectsTableItem( info, this.type ) );
+        }
     }
 
     /**

--- a/src/www/data/mechanics-6.xml
+++ b/src/www/data/mechanics-6.xml
@@ -638,7 +638,7 @@
             <object objectId="bow" price="7" unlimited="true" />
             <object objectId="quarterstaff" price="3" unlimited="true" />
             <object objectId="sword" price="4" unlimited="true" />
-            <object objectId="quiver" count="2" price="1" unlimited="true" />
+            <object objectId="arrow" count="2" price="1" unlimited="true" />
 
             <sell objectId="broadsword" price="6" />
             <sell objectId="dagger" price="1" />
@@ -650,7 +650,7 @@
             <sell objectId="bow" price="6" />
             <sell objectId="quarterstaff" price="2" />
             <sell objectId="sword" price="3" />
-            <sell objectId="quiver" count="4" price="1" />
+            <sell objectId="arrow" count="4" price="1" />
 
         </section>
 

--- a/src/www/data/objects.xml
+++ b/src/www/data/objects.xml
@@ -1237,8 +1237,7 @@
             <image book="1" name="pouch.png" />
         </object>
 
-        <!-- This not really an object, but needed for mechanics -->
-        <!-- TODO: Check this object, I think it can be removed (replaced by quiver) -->
+        <!-- Usually used as part of a quiver, but occasionally found by themselves -->
         <object id="arrow">
             <name lang="en">Arrows</name>
             <name lang="es">Flechas</name>


### PR DESCRIPTION
Here are the way quivers are apparently supposed to work (from book 8, sect168):

"A Quiver holds a maximum of six arrows, and to carry more than six arrows you will need to purchase an extra Quiver."

This logic has required a fair bit of reworking:
 - Arrows can now be normal objects decoupled from quivers (used for selling/buying mostly)
 - Arrows now allocate themselves to quivers in your inventory (there is a little oddity around this when you drop the first quiver in your inventory -- we actually drop the last quiver, to avoid dropping more arrows than needed -- I'm happy to change this, but this was simpler and it's an odd corner case)
 - A few places that dealt with quivers now handle arrows instead or in addition.

Please feel free to be nit picky, this is a bit of an intrusive change.