### PR TITLE
added Docker capability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:6.14.2
+RUN apt-get update
+RUN apt-get install -y zip 
+RUN apt-get install -y subversion
+WORKDIR /
+COPY . /
+RUN npm install
+RUN npm run ts
+RUN npm run downloaddata
+RUN npm install http-server -g
+RUN cat LICENSE
+EXPOSE 8080
+CMD ["http-server", "./src/www"]

--- a/README.md
+++ b/README.md
@@ -35,12 +35,22 @@ This will require Node.js (any recent version), zip command, SVN client, wget an
 
 ### Setup web site
 
+#### Method 1
+
 * Put the folder src/www on your private web server
 * Open http://localhost/[dir-for-src-www]/index.html
 
 You are now done. If you have Firefox, you dont need a web server. You can open
 directly the file src/www/index.html. This will not work with Chrome (see 
 http://stackoverflow.com/questions/10752055/cross-origin-requests-are-only-supported-for-http-error-when-loading-a-local)
+
+#### Method 2
+ 
+ * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
+ * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
+ * Type `docker build -t kai:1.0 .`
+ * Type `docker run -p 8080:8080 kai:1.0`
+ * Open http://localhost:8080
 
 ### Setup Android app
 


### PR DESCRIPTION
Make it easier to setup and run the app as a website. Install Docker on your system, build the image as represented by the Dockerfile, then run it.

I added this information to the README.md:

 * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
 * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
 * Type `docker build -t kai:1.0 .`
 * Type `docker run -p 8080:8080 kai:1.0`
 * Open http://localhost:8080