### PR TITLE
Feature/docker slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:6.14.2-slim
 RUN apt-get update && apt-get install -y zip && apt-get install -y subversion
-WORKDIR /
-COPY . /
+WORKDIR /srv/kai
+COPY . .
 EXPOSE 8080
-RUN npm install && npm run ts && npm run downloaddata && npm install http-server -g && cat LICENSE
+RUN npm install && npm run ts && npm run downloaddata
+RUN npm install http-server -g && cat LICENSE
 CMD ["http-server", "./src/www"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
-FROM node:6.14.2
-RUN apt-get update
-RUN apt-get install -y zip 
-RUN apt-get install -y subversion
+FROM node:6.14.2-slim
+RUN apt-get update && apt-get install -y zip && apt-get install -y subversion
 WORKDIR /
 COPY . /
-RUN npm install
-RUN npm run ts
-RUN npm run downloaddata
-RUN npm install http-server -g
-RUN cat LICENSE
 EXPOSE 8080
+RUN npm install && npm run ts && npm run downloaddata && npm install http-server -g && cat LICENSE
 CMD ["http-server", "./src/www"]

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Download the Project Aon game data:
 ```
 This will require Node.js (any recent version), zip command, SVN client, wget and patch on your path
 
-##### Alternative method
-###### Recommended for running a local website only to play the game
+### Alternative method
+#### Recommended for running a local website only to play the game
  * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
  * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
  * Type `docker build -t kai:1.0 .`

--- a/README.md
+++ b/README.md
@@ -35,16 +35,13 @@ This will require Node.js (any recent version), zip command, SVN client, wget an
 
 ##### Alternative method
 ###### Recommended for running a local website only to play the game
-This method downloads, configures and runs a local website for playing the game. If you intend to develop the game and are not familiar with Docker, then this method is not recommended.
  * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
- * `git clone` the repository (q.v. [basic instructions for Git](https://help.github.com/articles/cloning-a-repository/))
  * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
- * Type `docker build -t kai:1.10 .` (including the `.`)
- * Type `docker run -p 8080:8080 kai:1.10` 
+ * Type `docker build -t kai:1.0 .`
+ * Type `docker run -p 8080:8080 kai:1.0`
  * Open http://localhost:8080
-     * The build command only needs to be run once.
-     * If you want to access the site via a different port, change the *first* 8080 e.g. `docker run -p 5000:8080 kai:1.10`
-     * If you want to run the website independently of your terminal window (i.e. as a daemon), add a `-d` flag e.g. `docker run -d -p 8080:8080 kai:1.10`
+
+More information about this method [here](./doc/README-docker.md)
 
 ### Setup web site
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ work.
 
 ## Setup
 
+#### Method 1
+
 Compile Typescript
 ```bash
     npm install
@@ -33,9 +35,23 @@ Download the Project Aon game data:
 ```
 This will require Node.js (any recent version), zip command, SVN client, wget and patch on your path
 
+#### Method 2
+##### Only for running a local website. 
+This method downloads, configures and runs the website inside a Docker container.
+ * `git clone` the repository (q.v. basic instructions for Git)
+ * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
+ * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
+ * Type `docker build -t kai:1.10 .` 
+     * This command only needs to be run once.
+     * Remember to include the `.`
+ * Type `docker run -p 8080:8080 kai:1.10` 
+     * This command must be run again any time the container is stopped.
+     * If you want to access the site via a different port, change the *second* 8080 e.g. `docker run -p 8080:5000 kai:1.10`
+     * If you want to run the website independently of your terminal window (i.e. as a daemon), add a `-d` flag e.g. `docker run -d -p 8080:8080 kai:1.10`
+     * On Windows, by default, the container must be stopped manually.
+ * Open http://localhost:8080
+ 
 ### Setup web site
-
-#### Method 1
 
 * Put the folder src/www on your private web server
 * Open http://localhost/[dir-for-src-www]/index.html
@@ -43,14 +59,6 @@ This will require Node.js (any recent version), zip command, SVN client, wget an
 You are now done. If you have Firefox, you dont need a web server. You can open
 directly the file src/www/index.html. This will not work with Chrome (see 
 http://stackoverflow.com/questions/10752055/cross-origin-requests-are-only-supported-for-http-error-when-loading-a-local)
-
-#### Method 2
- 
- * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
- * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
- * Type `docker build -t kai:1.0 .`
- * Type `docker run -p 8080:8080 kai:1.0`
- * Open http://localhost:8080
 
 ### Setup Android app
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,13 @@ This method downloads, configures and runs a local website for playing the game.
  * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
  * `git clone` the repository (q.v. [basic instructions for Git](https://help.github.com/articles/cloning-a-repository/))
  * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
- * Type `docker build -t kai:1.10 .` 
-     * This command only needs to be run once.
-     * Remember to include the `.`
+ * Type `docker build -t kai:1.10 .` (including the `.`)
  * Type `docker run -p 8080:8080 kai:1.10` 
-     * If you want to access the site via a different port, change the *second* 8080 e.g. `docker run -p 8080:5000 kai:1.10`
-     * If you want to run the website independently of your terminal window (i.e. as a daemon), add a `-d` flag e.g. `docker run -d -p 8080:8080 kai:1.10`
-     * Run this command any time the container is stopped (i.e. you cannot access the website). On Windows, by default, the container must be stopped manually.
  * Open http://localhost:8080
- 
+     * The build command only needs to be run once.
+     * If you want to access the site via a different port, change the *first* 8080 e.g. `docker run -p 5000:8080 kai:1.10`
+     * If you want to run the website independently of your terminal window (i.e. as a daemon), add a `-d` flag e.g. `docker run -d -p 8080:8080 kai:1.10`
+
 ### Setup web site
 
 * Put the folder src/www on your private web server

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ work.
 
 ## Setup
 
-#### Method 1
-
 Compile Typescript
 ```bash
     npm install
@@ -35,20 +33,19 @@ Download the Project Aon game data:
 ```
 This will require Node.js (any recent version), zip command, SVN client, wget and patch on your path
 
-#### Method 2
-##### Only for running a local website. 
-This method downloads, configures and runs the website inside a Docker container.
- * `git clone` the repository (q.v. basic instructions for Git)
+##### Alternative method
+###### Recommended for running a local website only to play the game
+This method downloads, configures and runs a local website for playing the game. If you intend to develop the game and are not familiar with Docker, then this method is not recommended.
  * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
+ * `git clone` the repository (q.v. [basic instructions for Git](https://help.github.com/articles/cloning-a-repository/))
  * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
  * Type `docker build -t kai:1.10 .` 
      * This command only needs to be run once.
      * Remember to include the `.`
  * Type `docker run -p 8080:8080 kai:1.10` 
-     * This command must be run again any time the container is stopped.
      * If you want to access the site via a different port, change the *second* 8080 e.g. `docker run -p 8080:5000 kai:1.10`
      * If you want to run the website independently of your terminal window (i.e. as a daemon), add a `-d` flag e.g. `docker run -d -p 8080:8080 kai:1.10`
-     * On Windows, by default, the container must be stopped manually.
+     * Run this command any time the container is stopped (i.e. you cannot access the website). On Windows, by default, the container must be stopped manually.
  * Open http://localhost:8080
  
 ### Setup web site

--- a/doc/README-docker.md
+++ b/doc/README-docker.md
@@ -1,0 +1,13 @@
+# Docker
+
+Running Kai Chronicles inside a Docker cointainer configures and runs a local website for playing the game. If you intend to develop the game and are not familiar with Docker, then this method is not recommended.
+ * Download and install [Docker](https://docs.docker.com/install/) and make sure it's is in your PATH environment variable
+ * Using a terminal (Linux or iOS) or PowerShell (Windows 10) navigate to the project's directory
+ * Type `docker build -t kai:1.10 .` (including the `.`)
+     * The build command only needs to be run once.
+     * It takes awhile.
+ * Type `docker run -p 8080:8080 kai:1.10` 
+     * If you want to access the site via a different port, change the *first* 8080 e.g. `docker run -p 5000:8080 kai:1.10`
+     * If you want to run the website independently of your terminal window (i.e. as a daemon), add a `-d` flag e.g. `docker run -d -p 8080:8080 kai:1.10`
+ * Open http://localhost:8080
+     * The server's ready message has incorrect URLs. Use the URL above, with the correct port.

--- a/doc/README-docker.md
+++ b/doc/README-docker.md
@@ -9,5 +9,6 @@ Running Kai Chronicles inside a Docker cointainer configures and runs a local we
  * Type `docker run -p 8080:8080 kai:1.10` 
      * If you want to access the site via a different port, change the *first* 8080 e.g. `docker run -p 5000:8080 kai:1.10`
      * If you want to run the website independently of your terminal window (i.e. as a daemon), add a `-d` flag e.g. `docker run -d -p 8080:8080 kai:1.10`
+     * If you try this command and you get some kind of 'conflicting port' error, then try a different port per instructions above.
  * Open http://localhost:8080
-     * The server's ready message has incorrect URLs. Use the URL above, with the correct port.
+     * The server's ready message has incorrect URLs. Use the URL above, swapping in the correct port if you changed it.


### PR DESCRIPTION
Hi Toni.

There are two changes in this PR:

1)  [Per your comment](https://github.com/tonib/kaichronicles/pull/15#issuecomment-394104155) about Docker image size (1 GB on your machine, 650 MB on mine), this PR should reduce it (330 MB on my machine).  I used the 'slim' version of Nodejs as a base image. 

2) I also made some changes to the README file [(you can see those here)](https://github.com/rendall/kaichronicles/blob/feature/docker-slim/README.md) to help make things a bit clearer for newbies who might just want to run the game.

I feel like I should have broken these changes into separate pull requests.  Let me know if you'd rather I do that.

Later, I'll include a dev version of the Docker file, allowing devs to make changes and see their changes reflected in the local website but without installing and configuring all the dependencies.

