### PR TITLE
Add night mode

### DIFF
--- a/src/ts/controller/settingsController.ts
+++ b/src/ts/controller/settingsController.ts
@@ -52,6 +52,14 @@ const settingsController = {
         });
     },
 
+
+    /**
+     * Change the current color theme
+     */
+    changeColorTheme: function(color: string) : void {
+        template.changeColorTheme( color );
+    },
+
     /**
      * Show the save game dialog
      */

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -31,6 +31,11 @@ const state = {
     language: 'en',
 
     /**
+     * The current language ('en' = english / 'es' = spanish)
+     */
+    color: 'light',
+
+    /**
      * The local books download state for the Cordova app.
      * This member is not persisted
      */
@@ -45,6 +50,17 @@ const state = {
             return;
         if( navigator.language.toLowerCase().substr(0,2) == 'es' )
             state.language = 'es';
+    },
+
+    /**
+     * Setup the default color or persist from local storage
+     */
+    setupDefaultColorTheme: function() {
+        if( !state.existsPersistedState() ) {
+            state.color = 'light';
+            return;
+        }
+        state.color = JSON.parse(localStorage.getItem( 'state' )).color;
     },
 
     /**
@@ -111,7 +127,8 @@ const state = {
             bookNumber: state.book ? state.book.bookNumber : 0,
             actionChart: state.actionChart,
             sectionStates: state.sectionStates,
-            language: state.language
+            language: state.language,
+            color: state.color,
         };
     },
 
@@ -171,6 +188,7 @@ const state = {
         if( !stateKeys.actionChart.arrows )
             stateKeys.actionChart.arrows = 0;
             
+        state.color = stateKeys.color || 'light';
         state.language = stateKeys.language;
         state.book = new Book(stateKeys.bookNumber, state.language);
         state.mechanics = new Mechanics(state.book);
@@ -189,11 +207,19 @@ const state = {
     },
 
     /**
+     * Update state to change the book language
+     */
+    updateColorTheme: function(color) {
+        state.color = color;
+    },
+
+
+    /**
      * Restore objects on the Kai Monastery section from the Action Chart
      */
     restoreKaiMonasterySectionObjects : function() {
         const kaiMonasterySection = state.sectionStates.getSectionState( Book.KAIMONASTERY_SECTION );
-        kaiMonasterySection.objects = state.actionChart.kaiMonasterySafekeeping;
+        kaiMonasterySection.objects = state.actionChart ? state.actionChart.kaiMonasterySafekeeping : [];
     },
 
     /**

--- a/src/ts/template.ts
+++ b/src/ts/template.ts
@@ -57,6 +57,7 @@ const template = {
         });
         template.updateStatistics(true);
         template.translateMainMenu();
+        template.changeColorTheme(state.color);
 
         if( cordovaApp.isRunningApp() ) {
             // If we are on the cordova app, disable the animation (performance)
@@ -262,5 +263,23 @@ const template = {
             e.preventDefault();
             randomTable.randomTableUIClicked( parseInt( $(this).attr('data-number') ) );
         });
+    },
+
+    /**
+     * Change the color theme of the templates
+     */
+    changeColorTheme: function(theme: string) {
+        state.updateColorTheme( theme );
+        state.persistState();
+        
+        switch(theme) {
+            case 'dark':
+                $('body').addClass('dark');
+                break;
+            default:
+                // we will default to "light" theme, or no class
+                $('body').removeClass();
+                break;
+        }
     }
 };

--- a/src/ts/views/settingsView.ts
+++ b/src/ts/views/settingsView.ts
@@ -14,6 +14,12 @@ const settingsView = {
             settingsController.changeLanguage( $(this).val() , true );
         });
 
+        // Color theme
+        $('#settings-color-theme').val( state.color );
+        $('#settings-color-theme').change(function() {
+            settingsController.changeColorTheme($(this).val());
+        });
+
         // Random table type
         $('#settings-randomtable').val( state.actionChart.manualRandomTable ? 'manual' : 'computer' );
         $('#settings-randomtable').change(function() {

--- a/src/www/css/kaichronicles.css
+++ b/src/www/css/kaichronicles.css
@@ -282,3 +282,58 @@ td.center {
 #template-containertable tbody tr:nth-child(even) td:nth-child(even) {
    background-color: #ccc;
 }
+
+
+/**
+ * Dark Theme coloring
+*/
+body.dark {
+    background: #222;
+    color: #ccc;
+}
+
+
+body.dark .action.random.picked {
+    color: #ddd;
+}
+
+body.dark .well,
+body.dark .modal-content {
+    background: #333;
+}
+
+body.dark .btn img {
+    filter: invert(87%);
+}
+
+body.dark .btn-default, 
+body.dark .form-control[disabled], 
+body.dark .form-control[readonly], 
+body.dark fieldset[disabled], 
+body.dark .form-control {
+    color: #ccc;
+    background-color: #333;
+    border-color: #ddd;
+}
+
+/* List tables */
+body.dark .list-table {
+    border-color: #ddd;
+}
+body.dark .list-table li {
+    color: #ccc;
+    border-color: #ddd;
+}
+body.dark .list-table > li:nth-of-type(odd),
+body.dark .table-striped>tbody>tr:nth-of-type(odd) {
+    background-color: #333;
+}
+
+body.dark #template-containertable tbody tr:nth-child(odd) td:nth-child(odd),
+body.dark #template-containertable tbody tr:nth-child(even) td:nth-child(even) {
+    background-color: #222;
+ }
+
+body.dark #template-containertable {
+    border-color: #ddd!important;
+}

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -362,6 +362,7 @@
 
                 // Then do the real application setup
                 state.setupDefaultLanguage();
+                state.setupDefaultColorTheme();
                 template.setup();
                 routing.setup();
 

--- a/src/www/js/controller/mainMenuController.js
+++ b/src/www/js/controller/mainMenuController.js
@@ -32,6 +32,15 @@ var mainMenuController = {
         mainMenuController.index();
     },
 
+    /**
+     * Change the current color theme
+     */
+    changeColor: function() {
+        settingsController.changeColorTheme(state.color == 'light' ? 'dark' : 'light');
+        mainMenuController.index();
+    },
+
+
     /** Return page */
     getBackController: function() { return 'exitApp'; }
     

--- a/src/www/js/views/mainMenuView.js
+++ b/src/www/js/views/mainMenuView.js
@@ -28,6 +28,10 @@ var mainMenuView = {
             e.preventDefault();
             mainMenuController.changeTranslation();
         });
+        $('#menu-color-theme').click(function(e) {
+            e.preventDefault();
+            mainMenuController.changeColor();
+        });
         $('#menu-faq').click(function(e) {
             e.preventDefault();
             routing.redirect('faq');

--- a/src/www/views/mainMenu.html
+++ b/src/www/views/mainMenu.html
@@ -2,6 +2,9 @@
 
 <p>
     <a href="#" class="action" style="float:right" id="menu-translate">Spanish version</a>
+    <div style="float: right; padding-right: 25px;">
+        <a href="#" class="action" id="menu-color-theme">Change color</a>
+    </div>
     <b>v1.11</b><br/>
     <span data-translation="appInfo">
         This is a player for Lone Wolf game books 1 to 12.

--- a/src/www/views/settings.html
+++ b/src/www/views/settings.html
@@ -10,6 +10,16 @@
     </div>
 
     <div class="form-group">
+      <label for="settings-color-theme" data-translation="colorTheme">
+        Color Theme Selector
+      </label>
+      <select class="form-control" id="settings-color-theme">
+          <option value="light" data-translation="light">Light</option>
+          <option value="dark" data-translation="dark">Dark</option>
+      </select>
+  </div>
+
+    <div class="form-group">
         <label for="settings-randomtable" data-translation="randomTableValues">
           Random Number Table values
         </label>


### PR DESCRIPTION
I've touched a few different files to enable a dark mode. It should turn the background to a dark color (matches the navbar), and then text will go to a soft-white. Button images are inverted to make those less jarring, but all other images (e.g. illustrations) are left untouched. 

I added both a link type toggle in the main menu as well as a select option in the settings view. The choice is saved to state, and immediately the state is persisted.

I also only checked this in the browser.

*Note:* I also found a slight bug when trying to restart book 1, restoring kai monastery objects would throw an error. This was due to the `state.actionsheet` being `null`. I did a quick check for this and things seem to be fine now. I don't know if that was something I had messed up on my end or not, but I figured a check couldn't hurt.