### PR TITLE
Applying global rules to action chart stats

### DIFF
--- a/src/ts/controller/mechanics/mechanicsEngine.ts
+++ b/src/ts/controller/mechanics/mechanicsEngine.ts
@@ -789,11 +789,18 @@ const mechanicsEngine = {
 
         var sectionState = state.sectionStates.getSectionState();
         if( combatIndex >= sectionState.combats.length ) {
-            mechanicsEngine.debugWarning('Rule "combat": Combat with index ' +
-                combatIndex + ' not found');
-            return;
+            // are we just updating stats?
+            if(state.actionChart.combats[ combatIndex ]) {
+                var combat = state.actionChart.combats[ combatIndex ];
+            } else {
+                // no combats available...
+                mechanicsEngine.debugWarning('Rule "combat": Combat with index ' +
+                    combatIndex + ' not found. Not updating Action Chart stats either.');
+                return;
+            }
+        } else {
+            var combat = sectionState.combats[ combatIndex ];
         }
-        var combat = sectionState.combats[ combatIndex ];
 
         // Check LW combat ABSOLUTE skill modifier for this section:
         const combatSkillModifier = mechanicsEngine.getIntProperty( $rule , 'combatSkillModifier', true );
@@ -1215,6 +1222,9 @@ const mechanicsEngine = {
         }
 
         state.sectionStates.markRuleAsExecuted(rule);
+        // update stats in case global rule affects them...
+        actionChartView.updateStatistics();
+        template.updateStatistics();
     },
 
     /**
@@ -1224,6 +1234,10 @@ const mechanicsEngine = {
         var ruleId = $(rule).attr('id');
         console.log('Unregistering global rule ' + ruleId );
         state.sectionStates.globalRulesIds.removeValue(ruleId);
+        // update stats in case global rule affected them...
+        actionChartView.updateStatistics();
+        template.updateStatistics();
+
     },
 
     /**

--- a/src/ts/model/actionChart.ts
+++ b/src/ts/model/actionChart.ts
@@ -78,6 +78,9 @@ class ActionChart {
 
     /** The player has used adgana previously? (see "pouchadgana" object) */
     public adganaUsed = false;
+    
+    /** Container for a fake combat used to update stats, so rules can be applied to them */
+    public combats : Array<Combat> = [];
 
     /**
      * Restore 20 EP used?.
@@ -611,10 +614,17 @@ class ActionChart {
      */
     public getCurrentCombatSkillBonuses(combat : Combat = null) : Array<Bonus> {
 
-        if( !combat )
+        if( !combat ) {
             // Create a fake combat with the default values
-            combat = new Combat('Fake enemy' , 0 , 0 );
-
+            // make it in the action chart object so other parts of the system can read it
+            this.combats[0] = new Combat('Fake enemy' , 0 , 0 );
+            // apply all global rules (to setup disabled objects for example)
+            for (var i = 0; i < state.sectionStates.globalRulesIds.length; i++) {
+               var id = state.sectionStates.globalRulesIds[i];
+               mechanicsEngine.runChildRules(state.mechanics.getGlobalRule(id));
+            }
+            combat = this.combats[0];
+        }
         var bonuses = [];
 
         var currentWeapon = this.getSelectedWeaponItem( combat.bowCombat );
@@ -661,6 +671,9 @@ class ActionChart {
             for( let c of circlesBonuses )
                 bonuses.push(c);
         }
+
+        // remove fake combat from action chart object
+        delete this.combats[0];
 
         return bonuses;
     }


### PR DESCRIPTION
For example, in book 5 section 166 you lose the use of a shield. This is
taken into account for actual combats, but not for the fake combat
created to parse stats for simply updating the action chart. By making
the fake combat available as part of the action chart object, and
checking for that specifically when processing combat rules, any global
rules that affect stats will be reflected in the action chart.